### PR TITLE
Add filenames to assets

### DIFF
--- a/djangochurch_data/fixtures/djangochurch_assets.json
+++ b/djangochurch_data/fixtures/djangochurch_assets.json
@@ -18,7 +18,7 @@
     "fields": {
         "image_height": 362,
         "category": 2,
-        "file": "",
+        "file": "assets/image/remember.jpg",
         "title": "Remembrance",
         "image_width": 644
     },
@@ -29,7 +29,7 @@
     "fields": {
         "image_height": 353,
         "category": 1,
-        "file": "",
+        "file": "assets/image/sample-image-1.jpg",
         "title": "Sample image 1",
         "image_width": 644
     },
@@ -40,7 +40,7 @@
     "fields": {
         "image_height": 353,
         "category": 1,
-        "file": "",
+        "file": "assets/image/sample-image-2.jpg",
         "title": "Sample image 2",
         "image_width": 644
     },
@@ -51,7 +51,7 @@
     "fields": {
         "image_height": 353,
         "category": 1,
-        "file": "",
+        "file": "assets/image/sample-image-3.jpg",
         "title": "Sample image 3",
         "image_width": 644
     },
@@ -62,7 +62,7 @@
     "fields": {
         "image_height": 353,
         "category": 1,
-        "file": "",
+        "file": "assets/image/sample-image-4.jpg",
         "title": "Sample image 4",
         "image_width": 644
     },

--- a/djangochurch_data/management/commands/djangochurchimages.py
+++ b/djangochurch_data/management/commands/djangochurchimages.py
@@ -28,4 +28,4 @@ class Command(BaseCommand):
             image_file = os.path.join(image_dir, image_name)
 
             with open(image_file, 'rb') as f:
-                image.file.save(image_name, File(f))
+                image.file.save(image_name, File(f), save=False)


### PR DESCRIPTION
To avoid signals when loading the images, add the filenames into the fixtures and don't save when using the management command.